### PR TITLE
Capture more entropy in random key generation

### DIFF
--- a/bitcoin/main.py
+++ b/bitcoin/main.py
@@ -313,11 +313,11 @@ def electrum_sig_hash(message):
 
 def random_key():
     # Gotta be secure after that java.SecureRandom fiasco...
-    entropy = os.urandom(32)+str(random.randrange(2**256))+str(int(time.time()**7))
+    entropy = os.urandom(32)+str(random.randrange(2**256))+str(int(time.time()*1000000))
     return sha256(entropy)
 
 def random_electrum_seed():
-    entropy = os.urandom(32)+str(random.randrange(2**256))+str(int(time.time()**7))
+    entropy = os.urandom(32)+str(random.randrange(2**256))+str(int(time.time()*1000000))
     return sha256(entropy)[:32]
 
 ### Encodings


### PR DESCRIPTION
Hey @vbuterin, awesome library you've created. Thanks for putting it out there!

I was making some changes to bitmerchant and come across what I think is a weakness in your library. It's only a minor flaw, but I don't think this is behaving as you intended. Please see commit to understand what I'm doing, here is an example for clarity:

```
In [1]: import time

In [2]: example = time.time()

In [3]: example
Out[3]: 1399315452.479661

In [4]: int(example)  # destroys trailing 6 digits after decimal and makes this 10**6 times easier to brute-force
Out[4]: 1399315452

In [5]: int(example)**7  # not effective at preventing a brute force attack, as raising an int to the power of 7 is a trivial operation
Out[5]: 10505322981003921900367286428848137945904829534197528783971401728L

In [6]: int(example*1000000)  # captures all 6 trailing digits
Out[6]: 1399315452479661
```

The odds of a compromised CSPRNG are low, but I think this PR only improves pybitcointools with no downsides. I think your usage of `time.time()` is really clever, and this PR will improve the efficacy of that technique by 10**6.

You can see the bitmerchant discussion [here](https://github.com/sbuss/bitmerchant/pull/32).

---

As a side note, I'm not sure I agree with using `random.randrange` here. From [the docs](https://docs.python.org/dev/library/random.html):

> Warning: The pseudo-random generators of this module should not be used for security purposes. Use os.urandom() or SystemRandom if you require a cryptographically secure pseudo-random number generator.

Since it's adding entropy, I can't see it doing any harm either.
