### PR TITLE
A different approach to signall.

### DIFF
--- a/bitcoin/transaction.py
+++ b/bitcoin/transaction.py
@@ -323,10 +323,16 @@ def sign(tx, i, priv):
 
 
 def signall(tx, priv):
-    for i in range(len(deserialize(tx)["ins"])):
-        tx = sign(tx, i, priv)
+    # if priv is a dictionary, assume format is
+    # { 'txinhash:txinidx' : privkey }
+    if isinstance(priv, dict):
+        for e,i in enumerate(deserialize(tx)["ins"]):
+            k = priv["%s:%d" % (i["outpoint"]["hash"],i["outpoint"]["index"])]
+            tx = sign(tx, e, k)
+    else:
+        for i in range(len(deserialize(tx)["ins"])):
+            tx = sign(tx, i, priv)
     return tx
-
 
 def multisign(tx, i, script, pk, hashcode=SIGHASH_ALL):
     if re.match('^[0-9a-fA-F]*$', tx):


### PR DESCRIPTION
While still allowing 'sign all tx with this one key' a specific use case of mine is to have a dictionary of 'txid:vidx' to private keys. This commit adds support for that, though I'm not sure it is useful for anyone else.
