### PR TITLE
Install error in 1.1.17+ under python2.7

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,5 @@ setup(name='bitcoin',
       url='http://github.com/vbuterin/pybitcointools',
       install_requires='six==1.8.0',
       packages=['bitcoin'],
-      scripts=['pybtctool'],
-      data_files=[("", ["LICENSE"])]
+      scripts=['pybtctool']
       )


### PR DESCRIPTION
This line seems to break `pip install bitcoin` in 1.1.17 and onward. I'm using python2.7
https://github.com/vbuterin/pybitcointools/blame/master/setup.py#L14

https://gist.github.com/patcon/755e37cb57b588d29d6a

I believe pyethereum was working on python2.7 prior, but now its not

Also, you willing to accept a PR for travis support?
