### PR TITLE
Use low S-value for signatures

### DIFF
--- a/bitcoin/main.py
+++ b/bitcoin/main.py
@@ -548,6 +548,11 @@ def ecdsa_raw_sign(msghash, priv):
     r, y = fast_multiply(G, k)
     s = inv(k, N) * (z + r*decode_privkey(priv)) % N
 
+    # bitcoin enforces low S values, by negating the value (modulo the order)
+    # if larger than order/2
+    if s > N / 2: 
+        s = N - s
+
     return 27+(y % 2), r, s
 
 


### PR DESCRIPTION
The Satoshi client negates the S-value of a signature if the value is above half the order of the curve. The development version of the satoshi client enforces low S-values for signatures. But the stable version (0.9.3) only generates signatures this way, it does not enforce the check yet. From what I understand this change was made to help with malleability and has the added benefit of reducing the average serialised size of signatures.

See bitcoin/bitcoin#3016 and bitcoin/bitcoin#3637 and https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki for more information