### PR TITLE
Changing the der_encode_sig padding decision to avoid non-canonical sign...

### DIFF
--- a/bitcoin/transaction.py
+++ b/bitcoin/transaction.py
@@ -152,9 +152,9 @@ def signature_form(tx, i, script, hashcode=SIGHASH_ALL):
 
 def der_encode_sig(v, r, s):
     b1, b2 = safe_hexlify(encode(r, 256)), safe_hexlify(encode(s, 256))
-    if r >= 2**255:
+    if ord(b1.decode('hex')[0]) & 0x80 == 0x80:
         b1 = '00' + b1
-    if s >= 2**255:
+    if ord(b2.decode('hex')[0]) & 0x80 == 0x80:
         b2 = '00' + b2
     left = '02'+encode(len(b1)//2, 16, 2)+b1
     right = '02'+encode(len(b2)//2, 16, 2)+b2


### PR DESCRIPTION
...atures.

The negative number detection for R and S was flawed, sometimes creating non-canonical signatures where no padding was added to negative numbers, so I followed what was done here: https://code.google.com/p/bitcoinj/source/browse/core/src/main/java/com/google/bitcoin/crypto/TransactionSignature.java?r=354446dd40d7153ce5197e01c8a1ffe6b705bae3#94 which fixed the problem for me.
