### PR TITLE
Porting to Python 3

### DIFF
--- a/bitcoin/deterministic.py
+++ b/bitcoin/deterministic.py
@@ -1,7 +1,7 @@
 from bitcoin.main import *
 import hmac
 import hashlib
-
+from binascii import hexlify
 # Electrum wallets
 
 
@@ -59,8 +59,8 @@ def crack_electrum_wallet(mpk, pk, n, for_change=0):
     return subtract_privkeys(pk, offset)
 
 # Below code ASSUMES binary inputs and compressed pubkeys
-PRIVATE = '\x04\x88\xAD\xE4'
-PUBLIC = '\x04\x88\xB2\x1E'
+PRIVATE = b'\x04\x88\xAD\xE4'
+PUBLIC = b'\x04\x88\xB2\x1E'
 
 # BIP32 child key derivation
 
@@ -78,12 +78,12 @@ def raw_bip32_ckd(rawtuple, i):
     if i >= 2**31:
         if vbytes == PUBLIC:
             raise Exception("Can't do private derivation on public key!")
-        I = hmac.new(chaincode, '\x00'+priv[:32]+encode(i, 256, 4), hashlib.sha512).digest()
+        I = hmac.new(chaincode, b'\x00'+priv[:32]+encode(i, 256, 4), hashlib.sha512).digest()
     else:
         I = hmac.new(chaincode, pub+encode(i, 256, 4), hashlib.sha512).digest()
 
     if vbytes == PRIVATE:
-        newkey = add_privkeys(I[:32]+'\x01', priv)
+        newkey = add_privkeys(I[:32]+b'\x01', priv)
         fingerprint = bin_hash160(privtopub(key))[:4]
     if vbytes == PUBLIC:
         newkey = add_pubkeys(compress(privtopub(I[:32])), key)
@@ -94,11 +94,11 @@ def raw_bip32_ckd(rawtuple, i):
 
 def bip32_serialize(rawtuple):
     vbytes, depth, fingerprint, i, chaincode, key = rawtuple
-    depth = chr(depth % 256)
+    depth = depth % 256
     i = encode(i, 256, 4)
     chaincode = encode(hash_to_int(chaincode), 256, 32)
-    keydata = '\x00'+key[:-1] if vbytes == PRIVATE else key
-    bindata = vbytes + depth + fingerprint + i + chaincode + keydata
+    keydata = b'\x00'+key[:-1] if vbytes == PRIVATE else key
+    bindata = vbytes + bytes([depth]) + fingerprint + i + chaincode + keydata
     return changebase(bindata+bin_dbl_sha256(bindata)[:4], 256, 58)
 
 
@@ -107,11 +107,11 @@ def bip32_deserialize(data):
     if bin_dbl_sha256(dbin[:-4])[:4] != dbin[-4:]:
         raise Exception("Invalid checksum")
     vbytes = dbin[0:4]
-    depth = ord(dbin[4])
+    depth = dbin[4]
     fingerprint = dbin[5:9]
     i = decode(dbin[9:13], 256)
     chaincode = dbin[13:45]
-    key = dbin[46:78]+'\x01' if vbytes == PRIVATE else dbin[45:78]
+    key = dbin[46:78]+b'\x01' if vbytes == PRIVATE else dbin[45:78]
     return (vbytes, depth, fingerprint, i, chaincode, key)
 
 
@@ -129,8 +129,8 @@ def bip32_ckd(data, i):
 
 
 def bip32_master_key(seed):
-    I = hmac.new("Bitcoin seed", seed, hashlib.sha512).digest()
-    return bip32_serialize((PRIVATE, 0, '\x00'*4, 0, I[32:], I[:32]+'\x01'))
+    I = hmac.new(bytes("Bitcoin seed", "utf-8"), seed, hashlib.sha512).digest()
+    return bip32_serialize((PRIVATE, 0, b'\x00'*4, 0, I[32:], I[:32]+b'\x01'))
 
 
 def bip32_bin_extract_key(data):
@@ -155,7 +155,7 @@ def raw_crack_bip32_privkey(parent_pub, priv):
 
     I = hmac.new(pchaincode, pkey+encode(i, 256, 4), hashlib.sha512).digest()
 
-    pprivkey = subtract_privkeys(key, I[:32]+'\x01')
+    pprivkey = subtract_privkeys(key, I[:32]+b'\x01')
 
     return (PRIVATE, pdepth, pfingerprint, pi, pchaincode, pprivkey)
 
@@ -172,7 +172,7 @@ def coinvault_pub_to_bip32(*args):
     vals = map(int, args[34:])
     I1 = ''.join(map(chr, vals[:33]))
     I2 = ''.join(map(chr, vals[35:67]))
-    return bip32_serialize((PUBLIC, 0, '\x00'*4, 0, I2, I1))
+    return bip32_serialize((PUBLIC, 0, b'\x00'*4, 0, I2, I1))
 
 
 def coinvault_priv_to_bip32(*args):
@@ -181,7 +181,7 @@ def coinvault_priv_to_bip32(*args):
     vals = map(int, args[34:])
     I2 = ''.join(map(chr, vals[35:67]))
     I3 = ''.join(map(chr, vals[72:104]))
-    return bip32_serialize((PRIVATE, 0, '\x00'*4, 0, I2, I3+'\x01'))
+    return bip32_serialize((PRIVATE, 0, b'\x00'*4, 0, I2, I3+b'\x01'))
 
 
 def bip32_descend(*args):

--- a/bitcoin/deterministic.py
+++ b/bitcoin/deterministic.py
@@ -24,7 +24,7 @@ def electrum_privkey(seed, n, for_change=0):
     if len(seed) == 32:
         seed = electrum_stretch(seed)
     mpk = electrum_mpk(seed)
-    offset = dbl_sha256(str(n)+':'+str(for_change)+':'+binascii.unhexlify(mpk))
+    offset = dbl_sha256(bytes(str(n), 'utf-8')+b':'+bytes(str(for_change), 'utf-8')+b':'+binascii.unhexlify(mpk))
     return add_privkeys(seed, offset)
 
 # Accepts (seed or stretched seed or master pubkey), index and secondary index
@@ -39,7 +39,7 @@ def electrum_pubkey(masterkey, n, for_change=0):
     else:
         mpk = masterkey
     bin_mpk = encode_pubkey(mpk, 'bin_electrum')
-    offset = bin_dbl_sha256(str(n)+':'+str(for_change)+':'+bin_mpk)
+    offset = bin_dbl_sha256(bytes(str(n), 'utf-8')+b':'+bytes(str(for_change), 'utf-8')+b':'+bin_mpk)
     return add_pubkeys('04'+mpk, privtopub(offset))
 
 # seed/stretched seed/pubkey -> address (convenience method)
@@ -138,7 +138,7 @@ def bip32_bin_extract_key(data):
 
 
 def bip32_extract_key(data):
-    return binascii.hexlify(bip32_deserialize(data)[-1])
+    return str(binascii.hexlify(bip32_deserialize(data)[-1]), 'utf-8')
 
 # Exploits the same vulnerability as above in Electrum wallets
 # Takes a BIP32 pubkey and one of the child privkeys of its corresponding

--- a/bitcoin/main.py
+++ b/bitcoin/main.py
@@ -553,7 +553,7 @@ pubtoaddr = pubkey_to_address
 
 def encode_sig(v, r, s):
     vb, rb, sb = bytes([v]), encode(r, 256), encode(s, 256)
-    return base64.b64encode(vb+b'\x00'*(32-len(rb))+rb+b'\x00'*(32-len(sb))+sb)
+    return str(base64.b64encode(vb+b'\x00'*(32-len(rb))+rb+b'\x00'*(32-len(sb))+sb), 'utf-8')
 
 
 def decode_sig(sig):

--- a/bitcoin/main.py
+++ b/bitcoin/main.py
@@ -8,7 +8,7 @@ import base64
 import time
 import random
 import hmac
-import bitcoin.ripemd
+from bitcoin.ripemd import *
 import six
 
 # Elliptic curve parameters (secp256k1)
@@ -411,7 +411,7 @@ def bin_hash160(string):
     try:
         digest = hashlib.new('ripemd160', intermed).digest()
     except:
-        digest = ripemd.RIPEMD160(intermed).digest()
+        digest = RIPEMD160(intermed).digest()
     return digest
 
 
@@ -437,12 +437,12 @@ def bin_ripemd160(string):
     try:
         digest = hashlib.new('ripemd160', string).digest()
     except:
-        digest = ripemd.RIPEMD160(string).digest()
+        digest = RIPEMD160(string).digest()
     return digest
 
 
 def ripemd160(string):
-    return binascii.hexlify(bin_ripemd160(string))
+    return str(binascii.hexlify(bin_ripemd160(string)), 'utf-8')
 
 
 def bin_dbl_sha256(s):
@@ -451,7 +451,7 @@ def bin_dbl_sha256(s):
 
 
 def dbl_sha256(string):
-    return binascii.hexlify(bin_dbl_sha256(string))
+    return str(binascii.hexlify(bin_dbl_sha256(string)), 'utf-8')
 
 
 def bin_slowsha(string):
@@ -463,7 +463,7 @@ def bin_slowsha(string):
 
 
 def slowsha(string):
-    return binascii.hexlify(bin_slowsha(string))
+    return str(binascii.hexlify(bin_slowsha(string)), 'utf-8')
 
 
 def hash_to_int(x):
@@ -483,7 +483,7 @@ def num_to_var_int(x):
 
 # WTF, Electrum?
 def electrum_sig_hash(message):
-    padded = "\x18Bitcoin Signed Message:\n" + num_to_var_int(len(message)) + message
+    padded = b"\x18Bitcoin Signed Message:\n" + num_to_var_int(len(message)) + bytes(message, 'utf-8')
     return bin_dbl_sha256(padded)
 
 
@@ -552,13 +552,13 @@ pubtoaddr = pubkey_to_address
 
 
 def encode_sig(v, r, s):
-    vb, rb, sb = chr(v), encode(r, 256), encode(s, 256)
+    vb, rb, sb = bytes([v]), encode(r, 256), encode(s, 256)
     return base64.b64encode(vb+b'\x00'*(32-len(rb))+rb+b'\x00'*(32-len(sb))+sb)
 
 
 def decode_sig(sig):
     bytez = base64.b64decode(sig)
-    return ord(bytez[0]), decode(bytez[1:33], 256), decode(bytez[33:], 256)
+    return bytez[0], decode(bytez[1:33], 256), decode(bytez[33:], 256)
 
 # https://tools.ietf.org/html/rfc6979#section-3.2
 

--- a/bitcoin/main.py
+++ b/bitcoin/main.py
@@ -455,6 +455,7 @@ def dbl_sha256(string):
 
 
 def bin_slowsha(string):
+    string = bytes(string, 'utf-8') if isinstance(string, str) else string 
     orig_input = string
     for i in range(100000):
         string = hashlib.sha256(string + orig_input).digest()

--- a/bitcoin/main.py
+++ b/bitcoin/main.py
@@ -28,7 +28,7 @@ if is_python2:
         return b.encode('hex')
     
     def safe_from_hex(s):
-        return s.encode('hex')
+        return s.decode('hex')
     
     def from_int_representation_to_bytes(a):
         return str(a)
@@ -347,8 +347,8 @@ def fast_add(a, b):
 
 def get_pubkey_format(pub):
     if is_python2:
-        two = '0x02'
-        three = '0x03'
+        two = '\x02'
+        three = '\x03'
         four = '\x04'
     else:
         two = 2
@@ -387,7 +387,7 @@ def decode_pubkey(pub, formt=None):
     elif formt == 'bin_compressed':
         x = decode(pub[1:33], 256)
         beta = pow(int(x*x*x+A*x+B), int((P+1)//4), int(P))
-        y = (P-beta) if ((beta + pub[0]) % 2) else beta
+        y = (P-beta) if ((beta + from_byte_to_int(pub[0])) % 2) else beta
         return (x, y)
     elif formt == 'hex': return (decode(pub[2:66], 16), decode(pub[66:130], 16))
     elif formt == 'hex_compressed':

--- a/bitcoin/ripemd.py
+++ b/bitcoin/ripemd.py
@@ -44,7 +44,9 @@ except ImportError:
     pass
 
 from six.moves import range
+import sys
 
+is_python2 = sys.version_info.major == 2
 #block_size = 1
 digest_size = 20
 digestsize = 20
@@ -79,7 +81,10 @@ class RIPEMD160:
         dig = self.digest()
         hex_digest = ''
         for d in dig:
-            hex_digest += '%02x' % d
+            if (is_python2):
+                hex_digest += '%02x' % ord(d)
+            else:
+                hex_digest += '%02x' % d
         return hex_digest
     
     def copy(self):
@@ -157,7 +162,10 @@ import struct
 def RMD160Transform(state, block): #uint32 state[5], uchar block[64]
     x = [0]*16
     if sys.byteorder == 'little':
-        x = struct.unpack('<16L', bytes(block[0:64]))
+        if is_python2:
+            x = struct.unpack('<16L', ''.join([chr(x) for x in block[0:64]]))
+        else:
+            x = struct.unpack('<16L', bytes(block[0:64]))
     else:
         raise "Error!!"
     a = state[0]

--- a/bitcoin/ripemd.py
+++ b/bitcoin/ripemd.py
@@ -79,7 +79,7 @@ class RIPEMD160:
         dig = self.digest()
         hex_digest = ''
         for d in dig:
-            hex_digest += '%02x' % ord(d)
+            hex_digest += '%02x' % d
         return hex_digest
     
     def copy(self):
@@ -157,7 +157,7 @@ import struct
 def RMD160Transform(state, block): #uint32 state[5], uchar block[64]
     x = [0]*16
     if sys.byteorder == 'little':
-        x = struct.unpack('<16L', ''.join([chr(x) for x in block[0:64]]))
+        x = struct.unpack('<16L', bytes(block[0:64]))
     else:
         raise "Error!!"
     a = state[0]
@@ -364,7 +364,7 @@ def RMD160Update(ctx, inp, inplen):
     if type(inp) == str:
         inp = [ord(i)&0xff for i in inp]
     
-    have = int((ctx.count / 8) % 64)
+    have = int((ctx.count // 8) % 64)
     inplen = int(inplen)
     need = 64 - have
     ctx.count += 8 * inplen
@@ -386,7 +386,7 @@ def RMD160Update(ctx, inp, inplen):
 
 def RMD160Final(ctx):
     size = struct.pack("<Q", ctx.count)
-    padlen = 64 - ((ctx.count / 8) % 64)
+    padlen = 64 - ((ctx.count // 8) % 64)
     if padlen < 1+8:
         padlen += 64
     RMD160Update(ctx, PADDING, padlen-8)

--- a/bitcoin/transaction.py
+++ b/bitcoin/transaction.py
@@ -298,8 +298,8 @@ if is_python2:
 else:
     def serialize_script(script):
         if json_is_base(script, 16):
-            return str(binascii.hexlify(serialize_script(json_changebase(script,
-                                    lambda x: binascii.unhexlify(x)))), 'utf-8')
+            return safe_hexlify(serialize_script(json_changebase(script,
+                                    lambda x: binascii.unhexlify(x))))
         
         result = bytes()
         for b in map(serialize_script_unit, script):
@@ -376,7 +376,7 @@ def apply_multisignatures(*args):
         script = binascii.unhexlify(script)
     sigs = [binascii.unhexlify(x) if x[:2] == '30' else x for x in sigs]
     if isinstance(tx, str) and re.match('^[0-9a-fA-F]*$', tx):
-        return str(binascii.hexlify(apply_multisignatures(binascii.unhexlify(tx), i, script, sigs)), 'utf-8')
+        return safe_hexlify(apply_multisignatures(binascii.unhexlify(tx), i, script, sigs))
 
     txobj = deserialize(tx)
     txobj["ins"][i]["script"] = serialize_script([None]+sigs+[script])

--- a/bitcoin/transaction.py
+++ b/bitcoin/transaction.py
@@ -223,7 +223,7 @@ def address_to_script(addr):
 def script_to_address(script, vbyte=0):
     if re.match('^[0-9a-fA-F]*$', script):
         script = binascii.unhexlify(script)
-    if script[:3] == '\x76\xa9\x14' and script[-2:] == '\x88\xac' and len(script) == 25:
+    if script[:3] == b'\x76\xa9\x14' and script[-2:] == b'\x88\xac' and len(script) == 25:
         return bin_to_b58check(script[3:-2], vbyte)  # pubkey hash addresses
     else:
         if vbyte == 111:

--- a/test.py
+++ b/test.py
@@ -36,7 +36,6 @@ class TestECCArithmetic(unittest.TestCase):
                 add_pubkeys(multiply(G, hx), multiply(G, hy))[0],
                 multiply(G, add_privkeys(hx, hy))[0]
             )
-
             self.assertEqual(
                 b58check_to_hex(pubtoaddr(privtopub(x))),
                 b58check_to_hex(pubtoaddr(multiply(G, hx), 23))
@@ -107,6 +106,7 @@ class TestElectrumSignVerify(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.wallet = "/tmp/tempwallet_" + str(random.randrange(2**40))
+        print("Starting wallet tests with: " + cls.wallet)
         os.popen('echo "\n\n\n\n\n\n" | electrum -w %s create' % cls.wallet).read()
         cls.seed = str(json.loads(os.popen("electrum -w %s getseed" % cls.wallet).read())['seed'])
         cls.addies = json.loads(os.popen("electrum -w %s listaddresses" % cls.wallet).read())
@@ -146,7 +146,6 @@ class TestElectrumSignVerify(unittest.TestCase):
                 )
             )
 
-            
             mysig = ecdsa_sign(msg, priv)
             self.assertEqual(
                 os.popen('electrum -w %s verifymessage %s %s %s' % (self.wallet, addy, mysig, msg)).read().strip(),
@@ -286,7 +285,7 @@ class TestBIP0032(unittest.TestCase):
             [[2**31, 1, 2**31 + 2, 'pub', 2, 1000000000], 'xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy']
         ]
 
-        mk = bip32_master_key(bytes.fromhex('000102030405060708090a0b0c0d0e0f'))
+        mk = bip32_master_key(safe_from_hex('000102030405060708090a0b0c0d0e0f'))
 
         for tv in test_vectors:
             left, right = self._full_derive(mk, tv[0]), tv[1]
@@ -347,8 +346,8 @@ class TestRipeMD160PythonBackup(unittest.TestCase):
             hash160digest = ripemd.RIPEMD160(bin_sha256(s)).digest()
             self.assertEqual(bytes_to_hex_string(digest), target[i])
             self.assertEqual(bytes_to_hex_string(hash160digest), hash160target[i])
-            self.assertEqual(bytes_to_hex_string(bin_hash160(bytes(s, 'utf-8'))), hash160target[i])
-            self.assertEqual(hash160(bytes(s, 'utf-8')), hash160target[i])
+            self.assertEqual(bytes_to_hex_string(bin_hash160(from_string_to_bytes(s))), hash160target[i])
+            self.assertEqual(hash160(from_string_to_bytes(s)), hash160target[i])
 
 
 class TestScriptVsAddressOutputs(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -107,7 +107,6 @@ class TestElectrumSignVerify(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.wallet = "/tmp/tempwallet_" + str(random.randrange(2**40))
-        print("Starting wallet tests with: " + cls.wallet)
         os.popen('echo "\n\n\n\n\n\n" | electrum -w %s create' % cls.wallet).read()
         cls.seed = str(json.loads(os.popen("electrum -w %s getseed" % cls.wallet).read())['seed'])
         cls.addies = json.loads(os.popen("electrum -w %s listaddresses" % cls.wallet).read())
@@ -147,6 +146,7 @@ class TestElectrumSignVerify(unittest.TestCase):
                 )
             )
 
+            
             mysig = ecdsa_sign(msg, priv)
             self.assertEqual(
                 os.popen('electrum -w %s verifymessage %s %s %s' % (self.wallet, addy, mysig, msg)).read().strip(),
@@ -192,7 +192,6 @@ class TestSerialize(unittest.TestCase):
 
     def test_serialize_script(self):
         script = '47304402200c40fa58d3f6d5537a343cf9c8d13bc7470baf1d13867e0de3e535cd6b4354c802200f2b48f67494835b060d0b2ff85657d2ba2d9ea4e697888c8cb580e8658183a801483045022056f488c59849a4259e7cef70fe5d6d53a4bd1c59a195b0577bd81cb76044beca022100a735b319fa66af7b178fc719b93f905961ef4d4446deca8757a90de2106dd98a014cc95241046c7d87fd72caeab48e937f2feca9e9a4bd77f0eff4ebb2dbbb9855c023e334e188d32aaec4632ea4cbc575c037d8101aec73d029236e7b1c2380f3e4ad7edced41046fd41cddf3bbda33a240b417a825cc46555949917c7ccf64c59f42fd8dfe95f34fae3b09ed279c8c5b3530510e8cca6230791102eef9961d895e8db54af0563c410488d618b988efd2511fc1f9c03f11c210808852b07fe46128c1a6b1155aa22cdf4b6802460ba593db2d11c7e6cbe19cedef76b7bcabd05d26fd97f4c5a59b225053ae'
-        print("TEST", deserialize_script(script))
         self.assertEqual(
             serialize_script(deserialize_script(script)),
             script,
@@ -349,7 +348,6 @@ class TestRipeMD160PythonBackup(unittest.TestCase):
             self.assertEqual(bytes_to_hex_string(digest), target[i])
             self.assertEqual(bytes_to_hex_string(hash160digest), hash160target[i])
             self.assertEqual(bytes_to_hex_string(bin_hash160(bytes(s, 'utf-8'))), hash160target[i])
-            print("HASH160", hash160(bytes(s, 'utf-8')))
             self.assertEqual(hash160(bytes(s, 'utf-8')), hash160target[i])
 
 

--- a/test.py
+++ b/test.py
@@ -45,7 +45,6 @@ class TestECCArithmetic(unittest.TestCase):
             if i % 2 == 1:
                 p = changebase(p, 16, 256)
             self.assertEqual(p, decompress(compress(p)))
-
             self.assertEqual(G[0], multiply(divide(G, x), x)[0])
 
 

--- a/test.py
+++ b/test.py
@@ -108,7 +108,7 @@ class TestElectrumSignVerify(unittest.TestCase):
     def setUpClass(cls):
         cls.wallet = "/tmp/tempwallet_" + str(random.randrange(2**40))
         print("Starting wallet tests with: " + cls.wallet)
-        os.popen('echo -e "\n\n\n\n\n\n" | electrum -w %s create' % cls.wallet).read()
+        os.popen('echo "\n\n\n\n\n\n" | electrum -w %s create' % cls.wallet).read()
         cls.seed = str(json.loads(os.popen("electrum -w %s getseed" % cls.wallet).read())['seed'])
         cls.addies = json.loads(os.popen("electrum -w %s listaddresses" % cls.wallet).read())
 


### PR DESCRIPTION
The fix allows the library to work both with python2 and python3.
I have verified that in both interpreters the tests run correctly. This is the only verification I have run during my work.
When applicable, I have isolated the differences of the two interpreters in small functions.
I would expect that something will have to be changed just to make the fix cleaner.