### PR TITLE
Update py2specials.py

### DIFF
--- a/bitcoin/py2specials.py
+++ b/bitcoin/py2specials.py
@@ -60,7 +60,7 @@ if sys.version_info.major == 2:
     def from_byte_to_int(a):
         return ord(a)
 
-    def from_byes_to_string(s):
+    def from_bytes_to_string(s):
         return s
 
     def from_string_to_bytes(a):


### PR DESCRIPTION
mis-spelt bytes as "byes" in "from_bytes_to_string(s)", breaking 2.7 deserialize compatability amongst other things