### PR TITLE
bip62 low S

### DIFF
--- a/bitcoin/main.py
+++ b/bitcoin/main.py
@@ -486,7 +486,8 @@ def ecdsa_raw_sign(msghash, priv):
 
     r, y = fast_multiply(G, k)
     s = inv(k, N) * (z + r*decode_privkey(priv)) % N
-
+    if s > N//2:				# as per BIP62, low s value
+		s = N - s
     return 27+(y % 2), r, s
 
 


### PR DESCRIPTION
Return low S as per https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures