### PR TITLE
serialize_script fixed

### DIFF
--- a/bitcoin/transaction.py
+++ b/bitcoin/transaction.py
@@ -275,7 +275,7 @@ def serialize_script_unit(unit):
         if unit < 16:
             return from_int_to_byte(unit + 80)
         else:
-            return bytes([unit])
+            return from_int_to_byte(unit)
     elif unit is None:
         return b'\x00'
     else:
@@ -313,7 +313,7 @@ def mk_multisig_script(*args):  # [pubs],k or pub1,pub2...pub[n],k
     else:
         pubs = list(filter(lambda x: len(str(x)) >= 32, args))
         k = int(args[len(pubs)])
-    return serialize_script([k]+pubs+[len(pubs)]) + 'ae'
+    return serialize_script([k]+pubs+[len(pubs)]+[0xae])
 
 # Signing and verifying
 


### PR DESCRIPTION
fixed serialize_script

`serialize_script` was serializing hex representation of `[unit]` for int op_codes > 16 