### PR TITLE
Make script_to_address method work with dogecoin p2sh 

### DIFF
--- a/bitcoin/transaction.py
+++ b/bitcoin/transaction.py
@@ -231,7 +231,7 @@ def script_to_address(script, vbyte=0):
             # Testnet
             scripthash_byte = 196
         else:
-            scripthash_byte = 5
+            scripthash_byte = vbyte
         # BIP0016 scripthash addresses
         return bin_to_b58check(script[2:-1], scripthash_byte)
 


### PR DESCRIPTION
This seems to work now:
```
In [1]: from bitcoin.transaction import script_to_address

In [2]: script_to_address('a91467dbc5109dec5bf662df10378e91100cf3beeacb87', vbyte=22)
Out[2]: 'A1uRY29cvTYMTMruifFQ7EwN34iGDDpe7X'

In [3]: script_to_address('a914c56c24b77644fc44198eb3e2fee9bd276a13ed6c87', vbyte=5)
Out[3]: '3KgtbGgaX2ngstNpvyv7LwpHSweVeqGbpM'

In [4]: script_to_address('a914e32b88faeb7ce3e5d56d279ca7fac2ff47181bb587', vbyte=5)
Out[4]: '3NQBTxcD8jCQn4sSrs44NqF3q3htFMCgBf'
```

Fixes https://github.com/vbuterin/pybitcointools/issues/106