### PR TITLE
Support spending bare multisig inputs in apply_multisignatures

### DIFF
--- a/bitcoin/transaction.py
+++ b/bitcoin/transaction.py
@@ -378,8 +378,12 @@ def apply_multisignatures(*args):
     if isinstance(tx, str) and re.match('^[0-9a-fA-F]*$', tx):
         return safe_hexlify(apply_multisignatures(binascii.unhexlify(tx), i, script, sigs))
 
+    # Not pushing empty elements on the top of the stack if passing no
+    # script (in case of bare multisig inputs there is no script)
+    script_blob = [] if script.__len__() == 0 else [script]
+
     txobj = deserialize(tx)
-    txobj["ins"][i]["script"] = serialize_script([None]+sigs+[script])
+    txobj["ins"][i]["script"] = serialize_script([None]+sigs+script_blob)
     return serialize(txobj)
 
 


### PR DESCRIPTION
With this patch, subcommand `apply_multisignatures` does not put extra `OP_FALSE` to the end of scriptSig when passing empty string as script. Passing empty signature is needed when combining signatures for bare multisig inputs which don't have any embedded script (it is already included in parent tx)