### PR TITLE
typos in transaction.py prevent command line usage

### DIFF
--- a/bitcoin/transaction.py
+++ b/bitcoin/transaction.py
@@ -138,7 +138,7 @@ def signature_form(tx, i, script, hashcode=SIGHASH_ALL):
         newtx["outs"] = []
     elif hashcode == SIGHASH_SINGLE:
         newtx["outs"] = newtx["outs"][:len(newtx["ins"])]
-        for out in newtx["outs'][:len(newtx["ins"]) - 1)]:
+        for out in newtx["outs"][:len(newtx["ins"]) - 1]:
             out['value'] = 2**64 - 1
             out['script'] = ""
     elif hashcode == SIGHASH_ANYONECANPAY:


### PR DESCRIPTION
- wrong close-quote used in associative index
- extraneous parenthesis

```
 $ git config --get remote.upstream.url
https://github.com/vbuterin/pybitcointools.git

 $ git rev-parse @
da3fd128cd1cf29dedefc57d0223e312a2e7359e

 $ python2 pybtctool sha256 testing
Traceback (most recent call last):
  File "pybtctool", line 3, in <module>
    from bitcoin import *
  File "/home/scott/upsrc/pybitcointools/bitcoin/__init__.py", line 4, in <module>
    from bitcoin.transaction import *
  File "/home/scott/upsrc/pybitcointools/bitcoin/transaction.py", line 141
    for out in newtx["outs'][:len(newtx["ins"]) - 1)]:
                                           ^
SyntaxError: invalid syntax
```