### PR TITLE
Electrum 2 XPUB public master key

### DIFF
--- a/bitcoin/deterministic.py
+++ b/bitcoin/deterministic.py
@@ -42,6 +42,21 @@ def electrum_pubkey(masterkey, n, for_change=0):
     offset = bin_dbl_sha256(from_int_representation_to_bytes(n)+b':'+from_int_representation_to_bytes(for_change)+b':'+bin_mpk)
     return add_pubkeys('04'+mpk, privtopub(offset))
 
+# Accepts Electrum 2 XPUB master public key, index and secondary index
+# (conventionally 0 for ordinary addresses, 1 for change), returns pubkey
+
+def electrum_pubkey_v2(masterkey, n, for_change=0):
+    chain = bip32_ckd(masterkey, for_change)
+    child_key = bip32_ckd(chain, n)
+    return bip32_extract_key(child_key)
+
+# Accepts Electrum 2 XPUB master public key, index and secondary index
+# (conventionally 0 for ordinary addresses, 1 for change), returns address
+
+def electrum_address_v2(masterkey, n, for_change=0):
+    return pubkey_to_address(electrum_pubkey_v2(masterkey, n, for_change))
+
+
 # seed/stretched seed/pubkey -> address (convenience method)
 
 


### PR DESCRIPTION
Create keys and addresses from Electrum 2 XPUB public master key

New functions: electrum_pubkey_v2 and  electrum_address_v2.

Example code:

```python
#!/usr/bin/python3

from bitcoin import *


this_Electrum_v2_XPUB_master_public_key = "xpub661MyMwAqRbcFdBCo3DNoAd2jxiTshTYz2zdx7wDmnWtkFVe5Egzkb7dwsKbgGPj4SjEHSnRawewD1PJYLbQsZaXVGoaMQVmVc4SMXurZGw"

print ("\n * Public \"receive\" addresses: *\n\n")

for this_idx in range(0,6):

    this_public_key = electrum_pubkey_v2(this_Electrum_v2_XPUB_master_public_key, this_idx, 0) # 0: receive 1: change
    this_public_address = pubkey_to_address(this_public_key)

    this_public_address2 = electrum_address_v2(this_Electrum_v2_XPUB_master_public_key, this_idx, 0) # 0: receive 1: change

    print (this_public_address, this_public_address2)


print ("\n * Public \"change\" addresses: *\n\n")

for this_idx in range(0,6):

    this_public_key = electrum_pubkey_v2(this_Electrum_v2_XPUB_master_public_key, this_idx, 1) # 0: receive 1: change
    this_public_address = pubkey_to_address(this_public_key)

    this_public_address2 = electrum_address_v2(this_Electrum_v2_XPUB_master_public_key, this_idx, 1) # 0: receive 1: change

    print (this_public_address, this_public_address2)

```